### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,26 +6,26 @@
 # Datatypes (KEYWORD1)
 ##############################################
 
-DistanceGP2Y0A21YK  KEYWORD1
-DistanceSRF04 KEYWORD1
-DistanceGP2Y0A41SK  KEYWORD1
-CombinedDistanceSensors KEYWORD1
+DistanceGP2Y0A21YK	KEYWORD1
+DistanceSRF04	KEYWORD1
+DistanceGP2Y0A41SK	KEYWORD1
+CombinedDistanceSensors	KEYWORD1
 
 ##############################################
 # Methods and Functions (KEYWORD2)
 ##############################################
 
-begin KEYWORD2
-getDistanceRaw  KEYWORD2
-getDistanceVolt KEYWORD2
-getDistanceCentimeter KEYWORD2
-getDistanceTime KEYWORD2
-getDistanceInch KEYWORD2
+begin	KEYWORD2
+getDistanceRaw	KEYWORD2
+getDistanceVolt	KEYWORD2
+getDistanceCentimeter	KEYWORD2
+getDistanceTime	KEYWORD2
+getDistanceInch	KEYWORD2
 
-setAveraging  KEYWORD2
-setARefVoltage  KEYWORD2
-isCloser  KEYWORD2
-isFarther KEYWORD2
+setAveraging	KEYWORD2
+setARefVoltage	KEYWORD2
+isCloser	KEYWORD2
+isFarther	KEYWORD2
 
 ##############################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords